### PR TITLE
fix(ci): resolve strict clippy failures

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -190,11 +190,11 @@ fn main_menu(ctx: &egui::Context, game_state: &mut GameState, controls: &mut Con
             ui.visuals_mut().widgets.hovered.fg_stroke.color = button_text;
             ui.visuals_mut().widgets.active.fg_stroke.color = button_text;
             ui.visuals_mut().widgets.inactive.bg_stroke =
-                egui::Stroke::new(1.0, Color32::from_rgb(72, 76, 90));
+                egui::Stroke::new(1.0_f32, Color32::from_rgb(72, 76, 90));
             ui.visuals_mut().widgets.hovered.bg_stroke =
-                egui::Stroke::new(1.0, Color32::from_rgb(100, 108, 128));
+                egui::Stroke::new(1.0_f32, Color32::from_rgb(100, 108, 128));
             ui.visuals_mut().widgets.active.bg_stroke =
-                egui::Stroke::new(1.0, Color32::from_rgb(118, 128, 148));
+                egui::Stroke::new(1.0_f32, Color32::from_rgb(118, 128, 148));
 
             ui.vertical_centered(|ui| {
                 if ui

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -251,7 +251,7 @@ impl World {
     }
 
     fn process_construction(&mut self, dt: f64) {
-        for (_, infrastructure) in self.infrastructure.iter_mut() {
+        for infrastructure in self.infrastructure.values_mut() {
             infrastructure.process_construction(dt as f32);
         }
     }


### PR DESCRIPTION
## summary

- make the main-menu stroke widths explicitly `f32`
- iterate construction infrastructure through `values_mut()`
- restore compatibility with CI's `cargo clippy -- -D warnings`

## root cause

CI's current Rust toolchain enables a new float-literal fallback warning, while strict clippy also rejects key/value map iteration when only values are used. because the workflow promotes all warnings to errors, the existing code stopped passing lint without any related functional regression.

## impact

this is a behavior-preserving lint cleanup that restores the build pipeline on `main` and unblocks downstream PR checks.

## validation

- `cargo fmt --all`
- `cargo clippy`
- `cargo clippy -- -D warnings`
- `cargo test` (44 passed)