### PR TITLE
feat: add deterministic game screenshot capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,17 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 # follow the on-screen instructions, then ensure the stable toolchain is default:
 rustup default stable
 ```
+
+## agent screenshots
+
+render a deterministic game frame directly to a PNG and exit:
+
+```bash
+cargo run -- --seed 42 --start playing --ticks 300 \
+  --screenshot target/agent-captures/game.png --width 800 --height 600
+```
+
+the capture uses the native wgpu and egui renderers, advances the simulation by
+the requested number of fixed ticks, and does not depend on browser rendering.
+use `--start main-menu` without `--ticks` to capture the main menu. run
+`cargo run -- --help` for all options.

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,9 +1,13 @@
 //! the winit application: owns the window, gpu, egui, and game state, and
 //! drives the fixed-timestep sim. replaces the old hand-rolled sdl `main` loop.
 
+use std::path::PathBuf;
+use std::sync::mpsc;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use anyhow::{anyhow, Context};
+use tracing::info;
 use winit::application::ApplicationHandler;
 use winit::event::WindowEvent;
 use winit::event_loop::{ActiveEventLoop, ControlFlow};
@@ -27,6 +31,32 @@ pub const SIMULATION_DT: Duration = Duration::from_millis(10);
 /// render interval (about 60hz).
 pub const RENDER_DT: Duration = Duration::from_nanos(16_666_667);
 const ONE_SECOND: Duration = Duration::from_secs(1);
+
+#[derive(Debug)]
+pub struct CaptureConfig {
+    pub path: PathBuf,
+    pub seed: u64,
+    pub ticks: u64,
+    pub width: u32,
+    pub height: u32,
+    pub start_playing: bool,
+}
+
+struct CaptureRequest {
+    path: PathBuf,
+    width: u32,
+    height: u32,
+    warmup_frames_remaining: u8,
+    result: Option<anyhow::Result<()>>,
+}
+
+struct CaptureBuffer {
+    buffer: wgpu::Buffer,
+    padded_bytes_per_row: u32,
+    unpadded_bytes_per_row: u32,
+    width: u32,
+    height: u32,
+}
 
 /// the different interaction modes the game can be in.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -90,6 +120,7 @@ pub struct App {
     viewport: Viewport,
     game_state: GameState,
     background: BackgroundLayer,
+    capture: Option<CaptureRequest>,
 }
 
 impl App {
@@ -132,7 +163,46 @@ impl App {
             viewport: Viewport::default(),
             game_state: GameState::MainMenu,
             background,
+            capture: None,
         }
+    }
+
+    pub fn with_capture(config: CaptureConfig) -> Self {
+        let mut app = Self::with_seed(Some(config.seed));
+        if config.start_playing {
+            app.start_playing();
+        }
+        app.controls.paused = true;
+
+        for tick in 1..=config.ticks {
+            app.world.update(SIMULATION_DT.as_secs_f64(), tick);
+        }
+        app.clock.total_sim_ticks = config.ticks;
+        app.viewport.screen_pixel_width = config.width;
+        app.viewport.screen_pixel_height = config.height;
+        app.capture = Some(CaptureRequest {
+            path: config.path,
+            width: config.width,
+            height: config.height,
+            warmup_frames_remaining: 1,
+            result: None,
+        });
+        app
+    }
+
+    pub fn start_playing(&mut self) {
+        self.game_state = GameState::Playing;
+        self.controls.paused = false;
+    }
+
+    pub fn finish_capture(&mut self) -> anyhow::Result<()> {
+        let Some(capture) = self.capture.as_mut() else {
+            return Ok(());
+        };
+        capture
+            .result
+            .take()
+            .ok_or_else(|| anyhow!("game exited before the screenshot was captured"))?
     }
 
     /// render a single frame: clear (world pass) then composite egui on top.
@@ -147,6 +217,7 @@ impl App {
             clock,
             viewport,
             background,
+            capture,
             ..
         } = self;
         let (Some(gfx), Some(world_renderer), Some(egui)) =
@@ -158,6 +229,14 @@ impl App {
         // the galaxy is only drawn in the in-game states; the main menu shows
         // a bare background.
         let show_world = !matches!(game_state, GameState::MainMenu);
+        let screen = gfx
+            .capture_texture
+            .as_ref()
+            .map(|texture| (texture.width(), texture.height()))
+            .unwrap_or((gfx.config.width, gfx.config.height));
+        let should_capture = capture.as_ref().is_some_and(|request| {
+            request.result.is_none() && request.warmup_frames_remaining == 0
+        });
         if show_world {
             world_renderer.prepare(WorldPrepareContext {
                 device: &gfx.device,
@@ -166,16 +245,24 @@ impl App {
                 viewport,
                 background,
                 controls,
-                screen: (gfx.config.width, gfx.config.height),
+                screen,
             });
         }
 
-        let Some(output) = gfx.acquire_frame() else {
-            return;
+        let output = if gfx.capture_texture.is_some() {
+            None
+        } else {
+            let Some(output) = gfx.acquire_frame() else {
+                return;
+            };
+            Some(output)
         };
-        let view = output
-            .texture
-            .create_view(&wgpu::TextureViewDescriptor::default());
+        let target_texture = gfx
+            .capture_texture
+            .as_ref()
+            .or_else(|| output.as_ref().map(|output| &output.texture))
+            .expect("render target is available");
+        let view = target_texture.create_view(&wgpu::TextureViewDescriptor::default());
         let mut encoder = gfx.create_encoder();
 
         // world pass: clear to the scene background, then draw the tile world.
@@ -208,18 +295,59 @@ impl App {
                 queue: &gfx.queue,
                 encoder: &mut encoder,
                 view: &view,
-                screen_size_in_pixels: [gfx.config.width, gfx.config.height],
+                screen_size_in_pixels: [screen.0, screen.1],
             },
             |ctx| ui::build_ui(ctx, world, controls, game_state, clock, viewport),
         );
 
-        gfx.queue.submit(
+        let render_submission = gfx.queue.submit(
             user_buffers
                 .into_iter()
                 .chain(std::iter::once(encoder.finish())),
         );
-        output.present();
         clock.fps_counter += 1;
+
+        if should_capture {
+            let request = capture.as_mut().expect("capture request is pending");
+            let result = gfx
+                .device
+                .poll(wgpu::PollType::Wait {
+                    submission_index: Some(render_submission),
+                    timeout: None,
+                })
+                .context("waiting for screenshot render")
+                .and_then(|_| {
+                    let mut copy_encoder = gfx.create_encoder();
+                    let buffer = encode_capture(gfx, target_texture, &mut copy_encoder);
+                    gfx.queue.submit(std::iter::once(copy_encoder.finish()));
+                    save_capture(gfx, buffer, &request.path)
+                });
+            request.result = Some(result);
+            controls.quit_requested = true;
+        }
+
+        if let Some(output) = output {
+            output.present();
+        }
+
+        if let Some(request) = capture.as_mut() {
+            if request.result.is_none() && request.warmup_frames_remaining > 0 {
+                match gfx
+                    .device
+                    .poll(wgpu::PollType::wait_indefinitely())
+                    .context("waiting for screenshot warm-up frame")
+                {
+                    Ok(_) => {
+                        request.warmup_frames_remaining -= 1;
+                        gfx.window.request_redraw();
+                    }
+                    Err(error) => {
+                        request.result = Some(Err(error));
+                        controls.quit_requested = true;
+                    }
+                }
+            }
+        }
 
         // honor egui's requested repaint cadence (e.g. button hover animations).
         if repaint_now {
@@ -241,24 +369,48 @@ impl ApplicationHandler for App {
             return;
         }
 
-        let attributes = Window::default_attributes()
-            .with_title("sim")
-            .with_inner_size(winit::dpi::LogicalSize::new(
+        let attributes = Window::default_attributes().with_title("sim");
+        let attributes = if let Some(capture) = self.capture.as_ref() {
+            attributes.with_inner_size(winit::dpi::PhysicalSize::new(capture.width, capture.height))
+        } else {
+            attributes.with_inner_size(winit::dpi::LogicalSize::new(
                 INITIAL_WINDOW_WIDTH,
                 INITIAL_WINDOW_HEIGHT,
-            ));
+            ))
+        };
         let window = Arc::new(
             event_loop
                 .create_window(attributes)
                 .expect("failed to create window"),
         );
 
-        let gfx = GpuState::new(window.clone());
+        let capture_size = self
+            .capture
+            .as_ref()
+            .map(|capture| (capture.width, capture.height));
+        let gfx = GpuState::new(window.clone(), capture_size);
         let world_renderer = WorldRenderer::new(&gfx.device, &gfx.queue, gfx.config.format);
-        let egui = EguiLayer::new(&gfx.device, &window, gfx.config.format);
+        let pixels_per_point = self.capture.as_ref().map(|_| 1.0);
+        let egui = EguiLayer::new(&gfx.device, &window, gfx.config.format, pixels_per_point);
 
-        self.viewport.screen_pixel_width = gfx.config.width;
-        self.viewport.screen_pixel_height = gfx.config.height;
+        if self.capture.is_some() {
+            gfx.queue.submit(std::iter::empty());
+            if let Err(error) = gfx
+                .device
+                .poll(wgpu::PollType::wait_indefinitely())
+                .context("initializing screenshot GPU resources")
+            {
+                if let Some(capture) = self.capture.as_mut() {
+                    capture.result = Some(Err(error));
+                }
+                self.controls.quit_requested = true;
+            }
+        }
+
+        if self.capture.is_none() {
+            self.viewport.screen_pixel_width = gfx.config.width;
+            self.viewport.screen_pixel_height = gfx.config.height;
+        }
 
         self.gfx = Some(gfx);
         self.world_renderer = Some(world_renderer);
@@ -286,8 +438,10 @@ impl ApplicationHandler for App {
                 if let Some(gfx) = self.gfx.as_mut() {
                     gfx.resize(size.width, size.height);
                 }
-                self.viewport.screen_pixel_width = size.width;
-                self.viewport.screen_pixel_height = size.height;
+                if self.capture.is_none() {
+                    self.viewport.screen_pixel_width = size.width;
+                    self.viewport.screen_pixel_height = size.height;
+                }
             }
             WindowEvent::RedrawRequested => self.redraw(),
             other => {
@@ -361,4 +515,98 @@ impl ApplicationHandler for App {
         let wake_at = next_sim.min(next_render);
         event_loop.set_control_flow(ControlFlow::WaitUntil(wake_at));
     }
+}
+
+fn encode_capture(
+    gfx: &GpuState,
+    texture: &wgpu::Texture,
+    encoder: &mut wgpu::CommandEncoder,
+) -> CaptureBuffer {
+    let width = texture.width();
+    let height = texture.height();
+    let unpadded_bytes_per_row = width * 4;
+    let alignment = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
+    let padded_bytes_per_row = unpadded_bytes_per_row.div_ceil(alignment) * alignment;
+    let buffer = gfx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("screenshot readback"),
+        size: u64::from(padded_bytes_per_row) * u64::from(height),
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+
+    encoder.copy_texture_to_buffer(
+        texture.as_image_copy(),
+        wgpu::TexelCopyBufferInfo {
+            buffer: &buffer,
+            layout: wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(padded_bytes_per_row),
+                rows_per_image: None,
+            },
+        },
+        texture.size(),
+    );
+
+    CaptureBuffer {
+        buffer,
+        padded_bytes_per_row,
+        unpadded_bytes_per_row,
+        width,
+        height,
+    }
+}
+
+fn save_capture(
+    gfx: &GpuState,
+    capture: CaptureBuffer,
+    path: &std::path::Path,
+) -> anyhow::Result<()> {
+    let (sender, receiver) = mpsc::sync_channel(1);
+    capture
+        .buffer
+        .slice(..)
+        .map_async(wgpu::MapMode::Read, move |result| {
+            let _ = sender.send(result);
+        });
+    gfx.device
+        .poll(wgpu::PollType::wait_indefinitely())
+        .context("waiting for screenshot GPU readback")?;
+    receiver
+        .recv()
+        .context("receiving screenshot GPU readback")?
+        .context("mapping screenshot GPU buffer")?;
+
+    let channel_order = match gfx.config.format {
+        wgpu::TextureFormat::Rgba8Unorm | wgpu::TextureFormat::Rgba8UnormSrgb => [0, 1, 2, 3],
+        wgpu::TextureFormat::Bgra8Unorm | wgpu::TextureFormat::Bgra8UnormSrgb => [2, 1, 0, 3],
+        format => return Err(anyhow!("unsupported screenshot surface format {format:?}")),
+    };
+    let mapped = capture.buffer.slice(..).get_mapped_range();
+    let mut rgba = Vec::with_capacity((capture.width * capture.height * 4) as usize);
+    for padded_row in mapped.chunks(capture.padded_bytes_per_row as usize) {
+        let row = &padded_row[..capture.unpadded_bytes_per_row as usize];
+        for color in row.chunks_exact(4) {
+            rgba.extend(channel_order.map(|index| color[index]));
+        }
+    }
+    drop(mapped);
+    capture.buffer.unmap();
+
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating screenshot directory {}", parent.display()))?;
+    }
+    image::save_buffer(
+        path,
+        &rgba,
+        capture.width,
+        capture.height,
+        image::ColorType::Rgba8,
+    )
+    .with_context(|| format!("saving screenshot to {}", path.display()))?;
+    info!(path = %path.display(), width = capture.width, height = capture.height, "saved screenshot");
+    Ok(())
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,164 @@
+use std::path::PathBuf;
+
+use anyhow::{bail, Context};
+
+use crate::viewport::{INITIAL_WINDOW_HEIGHT, INITIAL_WINDOW_WIDTH};
+
+pub const HELP: &str = "usage: sim [options]\n\
+\n\
+options:\n\
+  --seed S             seed world generation and simulation\n\
+  --start STATE        start at main-menu or playing\n\
+  --ticks N            advance N fixed simulation ticks before capture\n\
+  --screenshot PATH    save one rendered frame as a PNG and exit\n\
+  --width PX           capture width in physical pixels (default: 800)\n\
+  --height PX          capture height in physical pixels (default: 600)\n\
+  -h, --help           print this help\n";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum StartState {
+    MainMenu,
+    Playing,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct CliOptions {
+    pub seed: Option<u64>,
+    pub start: Option<StartState>,
+    pub ticks: u64,
+    pub screenshot: Option<PathBuf>,
+    pub width: u32,
+    pub height: u32,
+    pub help: bool,
+}
+
+impl Default for CliOptions {
+    fn default() -> Self {
+        Self {
+            seed: None,
+            start: None,
+            ticks: 0,
+            screenshot: None,
+            width: INITIAL_WINDOW_WIDTH,
+            height: INITIAL_WINDOW_HEIGHT,
+            help: false,
+        }
+    }
+}
+
+impl CliOptions {
+    pub fn parse(args: impl IntoIterator<Item = String>) -> anyhow::Result<Self> {
+        let mut options = Self::default();
+        let mut args = args.into_iter();
+
+        while let Some(argument) = args.next() {
+            match argument.as_str() {
+                "-h" | "--help" => options.help = true,
+                "--seed" => {
+                    options.seed = Some(parse_value(&mut args, "--seed")?);
+                }
+                "--start" => {
+                    let value = next_value(&mut args, "--start")?;
+                    options.start = Some(match value.as_str() {
+                        "main-menu" => StartState::MainMenu,
+                        "playing" => StartState::Playing,
+                        _ => {
+                            bail!("invalid --start value {value:?}; expected main-menu or playing")
+                        }
+                    });
+                }
+                "--ticks" => options.ticks = parse_value(&mut args, "--ticks")?,
+                "--screenshot" => {
+                    options.screenshot =
+                        Some(PathBuf::from(next_value(&mut args, "--screenshot")?));
+                }
+                "--width" => options.width = parse_value(&mut args, "--width")?,
+                "--height" => options.height = parse_value(&mut args, "--height")?,
+                _ => bail!("unknown argument {argument:?}\n\n{HELP}"),
+            }
+        }
+
+        if options.width == 0 || options.height == 0 {
+            bail!("capture dimensions must be greater than zero");
+        }
+        if options.screenshot.is_none() && options.ticks != 0 {
+            bail!("--ticks requires --screenshot");
+        }
+        if options.start == Some(StartState::MainMenu) && options.ticks != 0 {
+            bail!("--ticks cannot be used with --start main-menu");
+        }
+
+        Ok(options)
+    }
+}
+
+fn next_value(args: &mut impl Iterator<Item = String>, option: &str) -> anyhow::Result<String> {
+    args.next()
+        .with_context(|| format!("{option} requires a value"))
+}
+
+fn parse_value<T>(args: &mut impl Iterator<Item = String>, option: &str) -> anyhow::Result<T>
+where
+    T: std::str::FromStr,
+    T::Err: std::error::Error + Send + Sync + 'static,
+{
+    let value = next_value(args, option)?;
+    value
+        .parse()
+        .with_context(|| format!("invalid value {value:?} for {option}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(args: &[&str]) -> anyhow::Result<CliOptions> {
+        CliOptions::parse(args.iter().map(|arg| (*arg).to_owned()))
+    }
+
+    #[test]
+    fn parses_capture_options() {
+        let options = parse(&[
+            "--seed",
+            "42",
+            "--start",
+            "playing",
+            "--ticks",
+            "300",
+            "--screenshot",
+            "capture.png",
+            "--width",
+            "1024",
+            "--height",
+            "768",
+        ])
+        .unwrap();
+
+        assert_eq!(options.seed, Some(42));
+        assert_eq!(options.start, Some(StartState::Playing));
+        assert_eq!(options.ticks, 300);
+        assert_eq!(options.screenshot, Some(PathBuf::from("capture.png")));
+        assert_eq!(options.width, 1024);
+        assert_eq!(options.height, 768);
+    }
+
+    #[test]
+    fn rejects_ticks_without_screenshot() {
+        let error = parse(&["--ticks", "1"]).unwrap_err();
+        assert!(error.to_string().contains("--ticks requires --screenshot"));
+    }
+
+    #[test]
+    fn rejects_ticks_for_main_menu_capture() {
+        let error = parse(&[
+            "--start",
+            "main-menu",
+            "--ticks",
+            "1",
+            "--screenshot",
+            "capture.png",
+        ])
+        .unwrap_err();
+        assert!(error.to_string().contains("--start main-menu"));
+    }
+}

--- a/src/egui_layer.rs
+++ b/src/egui_layer.rs
@@ -26,14 +26,16 @@ impl EguiLayer {
         device: &wgpu::Device,
         window: &Window,
         surface_format: wgpu::TextureFormat,
+        native_pixels_per_point: Option<f32>,
     ) -> Self {
         let ctx = egui::Context::default();
         let viewport_id = ctx.viewport_id();
+        let deterministic_capture = native_pixels_per_point.is_some();
         let state = egui_winit::State::new(
             ctx.clone(),
             viewport_id,
             window,
-            Some(window.scale_factor() as f32),
+            native_pixels_per_point.or(Some(window.scale_factor() as f32)),
             None,
             None,
         );
@@ -43,7 +45,7 @@ impl EguiLayer {
             egui_wgpu::RendererOptions {
                 msaa_samples: 1,
                 depth_stencil_format: None,
-                dithering: true,
+                dithering: !deterministic_capture,
                 predictable_texture_filtering: false,
             },
         );

--- a/src/gfx/mod.rs
+++ b/src/gfx/mod.rs
@@ -22,10 +22,11 @@ pub struct GpuState {
     pub device: wgpu::Device,
     pub queue: wgpu::Queue,
     pub config: wgpu::SurfaceConfiguration,
+    pub capture_texture: Option<wgpu::Texture>,
 }
 
 impl GpuState {
-    pub fn new(window: Arc<Window>) -> Self {
+    pub fn new(window: Arc<Window>, capture_size: Option<(u32, u32)>) -> Self {
         let size = window.inner_size();
 
         let instance = wgpu::Instance::default();
@@ -77,6 +78,22 @@ impl GpuState {
             desired_maximum_frame_latency: 2,
         };
         surface.configure(&device, &config);
+        let capture_texture = capture_size.map(|(width, height)| {
+            device.create_texture(&wgpu::TextureDescriptor {
+                label: Some("screenshot render target"),
+                size: wgpu::Extent3d {
+                    width,
+                    height,
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format: config.format,
+                usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+                view_formats: &[],
+            })
+        });
 
         Self {
             window,
@@ -84,6 +101,7 @@ impl GpuState {
             device,
             queue,
             config,
+            capture_texture,
         }
     }
 

--- a/src/location.rs
+++ b/src/location.rs
@@ -41,6 +41,10 @@ pub struct OrbitalParameters {
 #[derive(Debug, Default)]
 pub struct LocationSystem {
     entries: HashMap<EntityId, LocatedEntity>,
+    /// orbital IDs ordered by dependency depth, then entity ID. maintaining
+    /// this on mutation keeps simulation and rendering iteration deterministic
+    /// without sorting on their hot paths.
+    orbital_order: Vec<EntityId>,
 }
 
 #[derive(Debug)]
@@ -59,18 +63,20 @@ enum LocatedEntity {
 impl LocationSystem {
     /// Add a static (fixed) position for an entity.
     pub fn add_static(&mut self, entity: EntityId, position: Point) {
-        self.entries.insert(
+        let previous = self.entries.insert(
             entity,
             LocatedEntity::Static(PointF64 {
                 x: position.x as f64,
                 y: position.y as f64,
             }),
         );
+        self.remove_from_orbital_order_if_needed(entity, previous.as_ref());
     }
 
     /// Add a mobile entity.
     pub fn add_mobile(&mut self, entity: EntityId, position: PointF64) {
-        self.entries.insert(entity, LocatedEntity::Mobile(position));
+        let previous = self.entries.insert(entity, LocatedEntity::Mobile(position));
+        self.remove_from_orbital_order_if_needed(entity, previous.as_ref());
     }
 
     /// Add an orbital entry; initial position is computed relative to the anchor's current location.
@@ -87,7 +93,7 @@ impl LocationSystem {
             x: anchor_pos.x + radius * initial_angle.cos(),
             y: anchor_pos.y + radius * initial_angle.sin(),
         };
-        self.entries.insert(
+        let previous = self.entries.insert(
             entity,
             LocatedEntity::Orbital {
                 anchor,
@@ -97,15 +103,19 @@ impl LocationSystem {
                 position,
             },
         );
+        if !matches!(previous, Some(LocatedEntity::Orbital { .. })) {
+            self.orbital_order.push(entity);
+        }
+        self.sort_orbital_order();
     }
 
     /// number of orbital ancestors above `entity` (0 for a non-orbital or an
     /// orbital anchored to a static body). used to order the orbital update so
     /// parents advance before their children.
-    fn orbital_depth(&self, entity: EntityId) -> u32 {
+    fn orbital_depth(entries: &HashMap<EntityId, LocatedEntity>, entity: EntityId) -> u32 {
         let mut depth = 0;
         let mut current = entity;
-        while let Some(LocatedEntity::Orbital { anchor, .. }) = self.entries.get(&current) {
+        while let Some(LocatedEntity::Orbital { anchor, .. }) = entries.get(&current) {
             depth += 1;
             current = *anchor;
             // guard against malformed cycles in the anchor chain.
@@ -116,30 +126,41 @@ impl LocationSystem {
         depth
     }
 
+    fn sort_orbital_order(&mut self) {
+        let entries = &self.entries;
+        self.orbital_order
+            .sort_by_key(|&id| (Self::orbital_depth(entries, id), id));
+    }
+
+    fn remove_from_orbital_order_if_needed(
+        &mut self,
+        entity: EntityId,
+        previous: Option<&LocatedEntity>,
+    ) {
+        if matches!(previous, Some(LocatedEntity::Orbital { .. })) {
+            self.orbital_order.retain(|&id| id != entity);
+            self.sort_orbital_order();
+        }
+    }
+
     /// advance all orbitals by dt seconds, updating their positions. orbitals
     /// are processed parent-before-child so a body reads its anchor's fresh
     /// position within the same tick.
     pub fn update(&mut self, dt: f64) {
-        // collect all orbitals
-        let mut updates = Vec::new();
-        for (&id, loc) in &self.entries {
-            if let LocatedEntity::Orbital {
+        for index in 0..self.orbital_order.len() {
+            let id = self.orbital_order[index];
+            let Some(LocatedEntity::Orbital {
                 anchor,
                 radius,
                 angle,
                 angular_velocity,
                 ..
-            } = loc
-            {
-                updates.push((id, *anchor, *radius, *angle, *angular_velocity));
-            }
-        }
-        // sort so every orbital is processed after its anchor chain: children read
-        // their parent's freshly-updated position, and the order is deterministic
-        // (hashmap iteration order is unspecified, so collecting above is not).
-        updates.sort_by_key(|&(id, ..)| (self.orbital_depth(id), id));
-        // apply in order, so anchors update before children
-        for (id, anchor, radius, old_angle, angular_velocity) in updates {
+            }) = self.entries.get(&id)
+            else {
+                continue;
+            };
+            let (anchor, radius, old_angle, angular_velocity) =
+                (*anchor, *radius, *angle, *angular_velocity);
             let new_angle = old_angle + angular_velocity * dt;
             let anchor_pos = self.get_location_f64(anchor).unwrap_or_else(|| {
                 error!("update: anchor {} not found", anchor);
@@ -235,7 +256,8 @@ impl LocationSystem {
     }
 
     pub fn iter_orbitals(&self) -> impl Iterator<Item = (EntityId, OrbitalInfo)> + '_ {
-        self.entries.iter().filter_map(|(&id, loc)| {
+        self.orbital_order.iter().filter_map(|&id| {
+            let loc = self.entries.get(&id)?;
             if let LocatedEntity::Orbital { anchor, radius, .. } = loc {
                 Some((
                     id,
@@ -303,5 +325,51 @@ mod tests {
         let p = ls.get_location(1).unwrap();
         // cos(π/2)=0, sin(π/2)=1 => position should be (0, 10)
         assert_eq!(p, Point { x: 0, y: 10 });
+    }
+
+    #[test]
+    fn orbital_iteration_is_ordered_by_depth_then_id() {
+        let mut ls = LocationSystem::default();
+        ls.add_static(100, Point { x: 0, y: 0 });
+        ls.add_orbital(30, 100, 10.0, 0.0, 1.0);
+        ls.add_orbital(20, 100, 12.0, 0.0, 1.0);
+        // the child has the lowest ID but must follow both direct children.
+        ls.add_orbital(10, 20, 2.0, 0.0, 1.0);
+
+        let ids: Vec<_> = ls.iter_orbitals().map(|(id, _)| id).collect();
+
+        assert_eq!(ids, vec![20, 30, 10]);
+    }
+
+    #[test]
+    fn nested_orbitals_update_parent_before_child() {
+        let mut ls = LocationSystem::default();
+        ls.add_static(100, Point { x: 0, y: 0 });
+        ls.add_orbital(20, 100, 10.0, 0.0, std::f64::consts::FRAC_PI_2);
+        ls.add_orbital(10, 20, 2.0, 0.0, 0.0);
+
+        ls.update(1.0);
+
+        let child = ls.get_location_f64(10).unwrap();
+        assert!((child.x - 2.0).abs() < 1e-10);
+        assert!((child.y - 10.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn replacing_locations_maintains_orbital_order() {
+        let mut ls = LocationSystem::default();
+        ls.add_static(100, Point { x: 0, y: 0 });
+        ls.add_orbital(30, 100, 10.0, 0.0, 1.0);
+        ls.add_orbital(10, 30, 2.0, 0.0, 1.0);
+
+        // reparenting changes depth and therefore iteration order.
+        ls.add_orbital(10, 100, 2.0, 0.0, 1.0);
+        let ids: Vec<_> = ls.iter_orbitals().map(|(id, _)| id).collect();
+        assert_eq!(ids, vec![10, 30]);
+
+        // changing an orbital into a mobile entity removes it from the index.
+        ls.add_mobile(10, PointF64 { x: 1.0, y: 2.0 });
+        let ids: Vec<_> = ls.iter_orbitals().map(|(id, _)| id).collect();
+        assert_eq!(ids, vec![30]);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod app;
 mod background;
+mod cli;
 mod command;
 mod control_state;
 mod egui_layer;
@@ -17,6 +18,7 @@ mod ui;
 mod viewport;
 mod world;
 
+use anyhow::Context;
 use tracing::info;
 use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::EnvFilter;
@@ -25,7 +27,13 @@ use winit::event_loop::{ControlFlow, EventLoop};
 // re-exported so `crate::SIMULATION_DT` keeps resolving for the simulation code.
 pub use app::SIMULATION_DT;
 
-fn main() {
+fn main() -> anyhow::Result<()> {
+    let options = cli::CliOptions::parse(std::env::args().skip(1))?;
+    if options.help {
+        print!("{}", cli::HELP);
+        return Ok(());
+    }
+
     // default deps (winit/wgpu/naga) to warn so they don't flood the log, but
     // keep our own crate at debug. RUST_LOG still overrides everything.
     let env_filter = EnvFilter::builder()
@@ -40,8 +48,25 @@ fn main() {
     let event_loop = EventLoop::new().expect("failed to create event loop");
     event_loop.set_control_flow(ControlFlow::Wait);
 
-    let mut app = app::App::new();
+    let mut app = if let Some(path) = options.screenshot {
+        app::App::with_capture(app::CaptureConfig {
+            path,
+            seed: options.seed.unwrap_or(0),
+            ticks: options.ticks,
+            width: options.width,
+            height: options.height,
+            start_playing: options.start != Some(cli::StartState::MainMenu),
+        })
+    } else {
+        let mut app = app::App::with_seed(options.seed);
+        if options.start == Some(cli::StartState::Playing) {
+            app.start_playing();
+        }
+        app
+    };
     event_loop
         .run_app(&mut app)
-        .expect("event loop terminated with an error");
+        .context("event loop terminated with an error")?;
+    app.finish_capture()?;
+    Ok(())
 }


### PR DESCRIPTION
## what changed

- add a one-shot native wgpu screenshot path with deterministic seed, tick, start-state, and dimension inputs
- render the real world and egui overlay into an offscreen texture, read it back as PNG, and exit
- document the agent screenshot command and validate CLI arguments
- maintain deterministic parent-before-child orbital ordering in `LocationSystem`
- reuse that ordering in simulation updates and rendering, removing hot-path collection and sorting

## why

agents need a direct visual feedback loop that exercises the same renderer as the game without relying on a browser or OS-level screenshot tooling. deterministic orbital ordering is also required for stable alpha-blended output and belongs at mutation time rather than in frequent simulation and render reads.

## impact

agents can now produce a reproducible visual checkpoint with one command. normal interactive startup remains unchanged, while orbital updates avoid per-tick allocation and sorting.

## validation

- `cargo fmt --all`
- `cargo clippy`
- `cargo test` (50 tests)
- native 800x600 capture at seed 42 after 300 ticks, visually inspected with complete world and egui HUD