### PR TITLE
feat(ui): add floating planet panel and orbital infrastructure

### DIFF
--- a/docs/design/open-ideas.md
+++ b/docs/design/open-ideas.md
@@ -10,6 +10,12 @@ this doc parks ideas that are promising but not ready for implementation design.
 - orbital mining bases exploit resource-rich uninhabited bodies without consuming ship fuel.
 - imperial policy includes taxes, tariffs, subsidies, embargoes, and convoy escorts.
 
+## energy
+
+- energy should eventually be modeled as generation serving ongoing demand rather than as an ordinary stockpiled resource.
+- limited storage can buffer short consumption spikes and temporary generation gaps, but should not bank years of surplus to cover sustained overconsumption.
+- sustained generation deficits should have explicit consequences. the behavior when the short-term buffer reaches zero, including load shedding or reduced production, still needs design.
+
 ## research
 
 - research grants, breakthroughs, and captured data cores can accelerate progress.

--- a/docs/design/planetary-development.md
+++ b/docs/design/planetary-development.md
@@ -66,6 +66,13 @@ orbital build capability:
 - orbital infrastructure should not be hidden inside ground infrastructure, because it affects logistics and shipyard access differently.
 - solar panels are the first obvious orbital energy infrastructure.
 
+current prototype:
+
+- orbital infrastructure is built from and stored on its parent planet rather than represented as a separate entity.
+- the player can currently queue spaceports and orbital solar panels; existing ground infrastructure remains active but cannot be newly queued.
+- spaceports have no effect yet. completed orbital solar panels contribute to an informational energy-generation value.
+- this representation is intentionally temporary while orbital entities, logistics, and the full energy model remain open design topics.
+
 ## maybe later
 
 - districts, jobs, housing, amenities, and detailed workforce allocation.
@@ -78,6 +85,6 @@ orbital build capability:
 
 - should the first overview be opened from a keybind, a hud button, or both?
 - should overview selection replace the current world selection or mirror it?
-- should orbital infrastructure live on the planet record, on separate orbital entities, or both?
+- should the current planet-owned orbital infrastructure eventually move to separate orbital entities, or should both representations coexist?
 - how visible should exact efficiency modifiers be in the v1 ui?
 - should capacity be one shared budget or separate budgets for ground, orbit, and launch/logistics?

--- a/src/infrastructure.rs
+++ b/src/infrastructure.rs
@@ -38,6 +38,15 @@ impl EntityInfrastructure {
         self.infra.get(&infrastructure).copied().unwrap_or(0)
     }
 
+    /// gets the queued count of a specific infrastructure type.
+    pub fn get_queued_count(&self, infrastructure: InfrastructureType) -> u32 {
+        self.build_queue
+            .iter()
+            .filter(|(queued, _)| *queued == infrastructure)
+            .map(|(_, count)| *count)
+            .sum()
+    }
+
     /// processes the construction queue for a given time step.
     pub fn process_construction(&mut self, dt: f32) {
         if self.build_queue.is_empty() {
@@ -92,6 +101,9 @@ impl EntityInfrastructure {
     pub fn get_build_cost(infrastructure_type: InfrastructureType) -> HashMap<Storable, f32> {
         let mut costs = HashMap::new();
         match infrastructure_type {
+            InfrastructureType::Spaceport => {
+                costs.insert(Storable::Raw(RawResource::Metals), 100.0);
+            }
             InfrastructureType::SolarPanel => {
                 costs.insert(Storable::Raw(RawResource::Metals), 10.0);
                 costs.insert(Storable::Raw(RawResource::Crystals), 20.0);
@@ -125,7 +137,8 @@ impl EntityInfrastructure {
             InfrastructureType::Farm => "farm",
             InfrastructureType::Shipyard => "shipyard",
             InfrastructureType::ConstructionFactory => "construction factory",
-            InfrastructureType::SolarPanel => "solar panel",
+            InfrastructureType::Spaceport => "spaceport",
+            InfrastructureType::SolarPanel => "orbital solar panel",
         }
     }
 }
@@ -159,7 +172,11 @@ mod tests {
         );
         assert_eq!(
             EntityInfrastructure::infrastructure_name(InfrastructureType::SolarPanel),
-            "solar panel"
+            "orbital solar panel"
+        );
+        assert_eq!(
+            EntityInfrastructure::infrastructure_name(InfrastructureType::Spaceport),
+            "spaceport"
         );
     }
 
@@ -219,6 +236,27 @@ mod tests {
         assert_eq!(
             costs.get(&Storable::Raw(RawResource::Organics)),
             Some(&50.0)
+        );
+
+        let costs = EntityInfrastructure::get_build_cost(InfrastructureType::Spaceport);
+        assert_eq!(costs.len(), 1);
+        assert_eq!(costs.get(&Storable::Raw(RawResource::Metals)), Some(&100.0));
+    }
+
+    #[test]
+    fn queued_count_sums_matching_queue_entries() {
+        let mut infrastructure = EntityInfrastructure::new("test");
+        infrastructure.queue_build(InfrastructureType::Spaceport, 1);
+        infrastructure.queue_build(InfrastructureType::SolarPanel, 4);
+        infrastructure.queue_build(InfrastructureType::Spaceport, 2);
+
+        assert_eq!(
+            infrastructure.get_queued_count(InfrastructureType::Spaceport),
+            3
+        );
+        assert_eq!(
+            infrastructure.get_queued_count(InfrastructureType::SolarPanel),
+            4
         );
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -243,7 +243,10 @@ fn open_planet_overview(world: &World, controls: &ControlState, game_state: &mut
 /// (b) open the build menu if the selection is a player-controlled body.
 fn open_build_menu(world: &World, controls: &ControlState, game_state: &mut GameState) {
     if let Some(&id) = controls.selection.first() {
-        if world.is_player_controlled(id) && world.infrastructure.contains_key(&id) {
+        if world.is_player_controlled(id)
+            && world.get_entity_type(id) == Some(EntityType::Planet)
+            && world.infrastructure.contains_key(&id)
+        {
             *game_state = GameState::BuildMenu {
                 mode: BuildMenuMode::Main,
             };

--- a/src/map_generation.rs
+++ b/src/map_generation.rs
@@ -129,6 +129,9 @@ fn add_sol_system(world: &mut World) -> EntityId {
         earth_infrastructure
             .infra
             .insert(InfrastructureType::ConstructionFactory, 1);
+        earth_infrastructure
+            .infra
+            .insert(InfrastructureType::Spaceport, 1);
     }
 
     if let Some(earth_pos) = world.get_location(earth_id) {
@@ -333,6 +336,13 @@ mod tests {
         assert!(infrastructure.get_count(InfrastructureType::Farm) > 0);
         assert!(infrastructure.get_count(InfrastructureType::FuelCellCracker) > 0);
         assert!(infrastructure.get_count(InfrastructureType::Shipyard) > 0);
+        assert_eq!(
+            world.spaceport_for_planet(earth_id),
+            Some(crate::world::types::Spaceport {
+                name: "earth spaceport".to_string(),
+                size: crate::world::types::SpaceportSize::Small,
+            })
+        );
     }
 
     #[test]

--- a/src/ui/menus.rs
+++ b/src/ui/menus.rs
@@ -2,8 +2,6 @@
 //! drive the `GameState` machine and issue world commands, replacing the old
 //! sdl key handlers.
 
-use strum::IntoEnumIterator;
-
 use crate::app::{BuildMenuMode, GameState, MiningRouteMenuMode};
 use crate::command::Command;
 use crate::control_state::ControlState;
@@ -11,7 +9,9 @@ use crate::infrastructure::EntityInfrastructure;
 use crate::palette;
 use crate::ships::{buildable_ships, ShipBuildShortfall, ShipBuildable};
 use crate::world::components::MiningRoute;
-use crate::world::types::{EntityType, InfrastructureType, RawResource};
+use crate::world::types::{
+    EntityType, InfrastructureType, RawResource, PLAYER_BUILDABLE_INFRASTRUCTURE,
+};
 use crate::world::{EntityId, World};
 
 use super::{centered_window, raw_resource_display, storable_display};
@@ -76,7 +76,11 @@ pub fn planet_overview(
                         planet_detail(ui, world, body);
                         ui.separator();
                         ui.horizontal(|ui| {
-                            if ui.button("build").clicked() {
+                            let can_build = world.get_entity_type(body) == Some(EntityType::Planet);
+                            if ui
+                                .add_enabled(can_build, egui::Button::new("build"))
+                                .clicked()
+                            {
                                 controls.selection = vec![body];
                                 *game_state = GameState::BuildMenu {
                                     mode: BuildMenuMode::Main,
@@ -193,17 +197,30 @@ pub fn build_menu(
         *game_state = GameState::Playing;
         return;
     };
+    if !world.is_player_controlled(entity_id)
+        || world.get_entity_type(entity_id) != Some(EntityType::Planet)
+    {
+        *game_state = GameState::Playing;
+        return;
+    }
     let name = world.get_entity_name(entity_id).unwrap_or_default();
 
     centered_window(ctx, "build menu", |ui| {
         ui.heading(name.as_str());
         match mode {
             BuildMenuMode::Main => build_main(ui, world, game_state, entity_id),
-            BuildMenuMode::SelectInfrastructure => build_select(ui, game_state),
+            BuildMenuMode::SelectInfrastructure => build_select(ui, world, game_state, entity_id),
             BuildMenuMode::EnterQuantity {
                 infrastructure,
                 quantity_string,
-            } => build_quantity(ui, game_state, *infrastructure, quantity_string),
+            } => build_quantity(
+                ui,
+                world,
+                game_state,
+                entity_id,
+                *infrastructure,
+                quantity_string,
+            ),
             BuildMenuMode::ConfirmQuote {
                 infrastructure,
                 amount,
@@ -238,11 +255,17 @@ fn build_main(ui: &mut egui::Ui, world: &World, game_state: &mut GameState, enti
     }
 }
 
-fn build_select(ui: &mut egui::Ui, game_state: &mut GameState) {
-    ui.label("select infrastructure:");
-    for infrastructure in InfrastructureType::iter() {
+fn build_select(ui: &mut egui::Ui, world: &World, game_state: &mut GameState, entity_id: EntityId) {
+    ui.label("select orbital infrastructure:");
+    for &infrastructure in PLAYER_BUILDABLE_INFRASTRUCTURE {
+        let available = world.can_queue_player_infrastructure(entity_id, infrastructure, 1);
+        let label = if infrastructure == InfrastructureType::Spaceport && !available {
+            "spaceport (maximum size)"
+        } else {
+            EntityInfrastructure::infrastructure_name(infrastructure)
+        };
         if ui
-            .button(EntityInfrastructure::infrastructure_name(infrastructure))
+            .add_enabled(available, egui::Button::new(label))
             .clicked()
         {
             *game_state = GameState::BuildMenu {
@@ -262,7 +285,9 @@ fn build_select(ui: &mut egui::Ui, game_state: &mut GameState) {
 
 fn build_quantity(
     ui: &mut egui::Ui,
+    world: &World,
     game_state: &mut GameState,
+    entity_id: EntityId,
     infrastructure: InfrastructureType,
     quantity_string: &str,
 ) {
@@ -270,12 +295,27 @@ fn build_quantity(
         "infrastructure: {}",
         EntityInfrastructure::infrastructure_name(infrastructure)
     ));
+    if infrastructure == InfrastructureType::Spaceport {
+        ui.label(format!(
+            "units available before large: {}",
+            world.remaining_spaceport_units(entity_id)
+        ));
+    }
     let mut qty = quantity_string.to_string();
     let response = ui.add(egui::TextEdit::singleline(&mut qty).hint_text("quantity"));
     let amount = qty.trim().parse::<u32>().ok().filter(|n| *n > 0);
+    let eligible = amount.is_some_and(|amount| {
+        world.can_queue_player_infrastructure(entity_id, infrastructure, amount)
+    });
+    if infrastructure == InfrastructureType::Spaceport && amount.is_some() && !eligible {
+        ui.colored_label(
+            palette::RED,
+            "quantity exceeds the available spaceport size",
+        );
+    }
     let enter = response.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter));
     let confirm = ui
-        .add_enabled(amount.is_some(), egui::Button::new("confirm"))
+        .add_enabled(eligible, egui::Button::new("confirm"))
         .clicked();
     let cancel = ui.button("cancel").clicked();
 
@@ -283,7 +323,7 @@ fn build_quantity(
         *game_state = GameState::BuildMenu {
             mode: BuildMenuMode::Main,
         };
-    } else if (enter || confirm) && amount.is_some() {
+    } else if (enter || confirm) && eligible {
         *game_state = GameState::BuildMenu {
             mode: BuildMenuMode::ConfirmQuote {
                 infrastructure,
@@ -332,7 +372,8 @@ fn build_confirm(
         ui.colored_label(color, format!("  {cost:.1} {storable} (have {have:.1})"));
     }
     ui.horizontal(|ui| {
-        if ui.button("yes").clicked() {
+        let eligible = world.can_queue_player_infrastructure(entity_id, infrastructure, amount);
+        if ui.add_enabled(eligible, egui::Button::new("yes")).clicked() {
             world.add_command(Command::Build {
                 entity_id,
                 infrastructure_type: infrastructure,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -4,15 +4,20 @@
 
 mod menus;
 
-use egui::{Align2, Color32, Vec2};
+use egui::{Align2, Color32, Pos2, Rect, Vec2};
 
 use crate::app::GameState;
 use crate::control_state::ControlState;
 use crate::palette;
 use crate::sim_clock::SimClock;
 use crate::viewport::Viewport;
-use crate::world::types::{Good, RawResource, Storable};
-use crate::world::World;
+use crate::world::types::{EntityType, Good, RawResource, Spaceport, Storable};
+use crate::world::{EntityId, World};
+
+const PLANET_PANEL_WIDTH: f32 = 240.0;
+const PLANET_PANEL_ESTIMATED_HEIGHT: f32 = 240.0;
+const PLANET_PANEL_GAP: f32 = 24.0;
+const PLANET_PANEL_MARGIN: f32 = 8.0;
 
 /// build the whole frame's ui.
 pub fn build_ui(
@@ -28,7 +33,7 @@ pub fn build_ui(
     // hud is shown over the world in every in-game state.
     if shows_world(&state) {
         hud_panels(ctx, world, controls, clock, viewport);
-        selected_object_panel(ctx, world, controls);
+        selected_object_panel(ctx, world, controls, viewport);
     }
 
     match state {
@@ -94,10 +99,28 @@ fn hud_panels(
         });
 }
 
-fn selected_object_panel(ctx: &egui::Context, world: &World, controls: &ControlState) {
+fn selected_object_panel(
+    ctx: &egui::Context,
+    world: &World,
+    controls: &ControlState,
+    viewport: &Viewport,
+) {
     if controls.selection.is_empty() {
         return;
     }
+
+    if controls.selection.len() == 1 {
+        let selected = controls.selection[0];
+        if world.get_entity_type(selected) == Some(EntityType::Planet) {
+            if let Some(screen_position) =
+                visible_entity_screen_position(ctx, world, viewport, selected)
+            {
+                floating_planet_panel(ctx, world, controls, selected, screen_position);
+                return;
+            }
+        }
+    }
+
     egui::Area::new("selected_object".into())
         .anchor(Align2::LEFT_BOTTOM, Vec2::new(8.0, -8.0))
         .show(ctx, |ui| {
@@ -115,6 +138,157 @@ fn selected_object_panel(ctx: &egui::Context, world: &World, controls: &ControlS
                     if ships > 0 {
                         ui.colored_label(palette::GRAY, format!("- {ships} ships"));
                     }
+                }
+            });
+        });
+}
+
+#[derive(Debug, PartialEq)]
+struct PlanetPanelData {
+    name: String,
+    system_name: String,
+    moon_count: usize,
+    resources: Vec<(RawResource, f32)>,
+    energy_generation: f32,
+    solar_panel_count: u32,
+    spaceport: Option<Spaceport>,
+}
+
+fn planet_panel_data(world: &World, planet_id: EntityId) -> Option<PlanetPanelData> {
+    if world.get_entity_type(planet_id) != Some(EntityType::Planet) {
+        return None;
+    }
+
+    let name = world.get_entity_name(planet_id)?;
+    let system_name = world
+        .find_star_for_entity(planet_id)
+        .and_then(|star_id| world.get_entity_name(star_id))
+        .unwrap_or_else(|| "unknown".to_string());
+    let mut resources: Vec<_> = world
+        .celestial_data
+        .get(&planet_id)
+        .map(|data| {
+            data.yields
+                .iter()
+                .map(|(&resource, &grade)| (resource, grade))
+                .collect()
+        })
+        .unwrap_or_default();
+    resources.sort_by_key(|(resource, _)| *resource);
+    let solar_panel_count = world
+        .infrastructure
+        .get(&planet_id)
+        .map(|infrastructure| {
+            infrastructure.get_count(crate::world::types::InfrastructureType::SolarPanel)
+        })
+        .unwrap_or(0);
+
+    Some(PlanetPanelData {
+        name,
+        system_name,
+        moon_count: world.direct_moon_count(planet_id),
+        resources,
+        energy_generation: world.energy_generation_for_body(planet_id),
+        solar_panel_count,
+        spaceport: world.spaceport_for_planet(planet_id),
+    })
+}
+
+fn visible_entity_screen_position(
+    ctx: &egui::Context,
+    world: &World,
+    viewport: &Viewport,
+    entity_id: EntityId,
+) -> Option<Pos2> {
+    let location = world.get_location_f64(entity_id)?;
+    let (screen_x, screen_y) = viewport.world_to_screen_px(location.x, location.y);
+    if screen_x < 0.0
+        || screen_y < 0.0
+        || screen_x > viewport.screen_pixel_width as f64
+        || screen_y > viewport.screen_pixel_height as f64
+    {
+        return None;
+    }
+
+    let pixels_per_point = ctx.pixels_per_point();
+    Some(Pos2::new(
+        screen_x as f32 / pixels_per_point,
+        screen_y as f32 / pixels_per_point,
+    ))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct PlanetPanelPlacement {
+    position: Pos2,
+    pivot: Align2,
+}
+
+fn planet_panel_placement(planet: Pos2, screen: Rect) -> PlanetPanelPlacement {
+    let fits_left =
+        planet.x - PLANET_PANEL_GAP - PLANET_PANEL_WIDTH >= screen.left() + PLANET_PANEL_MARGIN;
+    let (position_x, pivot) = if fits_left {
+        (planet.x - PLANET_PANEL_GAP, Align2::RIGHT_CENTER)
+    } else {
+        (planet.x + PLANET_PANEL_GAP, Align2::LEFT_CENTER)
+    };
+    let half_height = PLANET_PANEL_ESTIMATED_HEIGHT / 2.0;
+    let min_y = screen.top() + PLANET_PANEL_MARGIN + half_height;
+    let max_y = screen.bottom() - PLANET_PANEL_MARGIN - half_height;
+    let position_y = if min_y <= max_y {
+        planet.y.clamp(min_y, max_y)
+    } else {
+        screen.center().y
+    };
+
+    PlanetPanelPlacement {
+        position: Pos2::new(position_x, position_y),
+        pivot,
+    }
+}
+
+fn floating_planet_panel(
+    ctx: &egui::Context,
+    world: &World,
+    controls: &ControlState,
+    planet_id: EntityId,
+    screen_position: Pos2,
+) {
+    let Some(data) = planet_panel_data(world, planet_id) else {
+        return;
+    };
+    let screen = ctx.content_rect();
+    let placement = planet_panel_placement(screen_position, screen);
+
+    egui::Area::new("selected_planet".into())
+        .fixed_pos(placement.position)
+        .pivot(placement.pivot)
+        .constrain_to(screen)
+        .show(ctx, |ui| {
+            egui::Frame::popup(ui.style()).show(ui, |ui| {
+                ui.set_width(PLANET_PANEL_WIDTH);
+                if controls.track_mode {
+                    ui.colored_label(palette::WHITE, "tracking");
+                }
+                ui.heading(data.name);
+                ui.label(format!("system: {}", data.system_name));
+                ui.label(format!("moons: {}", data.moon_count));
+                ui.separator();
+                ui.label("available resources");
+                if data.resources.is_empty() {
+                    ui.colored_label(palette::DGRAY, "  (none)");
+                } else {
+                    for (resource, grade) in data.resources {
+                        let (label, color) = raw_resource_display(resource);
+                        ui.colored_label(color, format!("  {label}: {grade:.2}"));
+                    }
+                }
+                ui.separator();
+                ui.label(format!("energy generation: {:.0}", data.energy_generation));
+                ui.label(format!("orbital solar panels: {}", data.solar_panel_count));
+                if let Some(spaceport) = data.spaceport {
+                    ui.separator();
+                    ui.label(format!("spaceport: {}", spaceport.name));
+                    ui.label(format!("size: {}", spaceport.size.label()));
                 }
             });
         });
@@ -257,5 +431,66 @@ fn storable_display(storable: Storable) -> (&'static str, Color32) {
         Storable::Raw(r) => raw_resource_display(r),
         Storable::Good(Good::FuelCells) => ("fuel cells", palette::RED),
         Storable::Good(Good::Food) => ("food", palette::GREEN),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::location::Point;
+    use crate::world::types::{InfrastructureType, RawResource, SpaceportSize};
+
+    #[test]
+    fn planet_panel_data_is_sorted_and_uses_completed_orbital_infrastructure() {
+        let mut world = World::default();
+        let star_id = world.spawn_star("sol".to_string(), Point { x: 0, y: 0 });
+        let planet_id = world.spawn_planet("earth".to_string(), star_id, 10.0, 0.0, 0.0);
+        world.spawn_moon("moon".to_string(), planet_id, 2.0, 0.0, 0.0);
+        let body = world.celestial_data.get_mut(&planet_id).unwrap();
+        body.yields.clear();
+        body.yields.insert(RawResource::Crystals, 2.0);
+        body.yields.insert(RawResource::Metals, 1.0);
+        let infrastructure = world.infrastructure.get_mut(&planet_id).unwrap();
+        infrastructure
+            .infra
+            .insert(InfrastructureType::Spaceport, 1);
+        infrastructure
+            .infra
+            .insert(InfrastructureType::SolarPanel, 2);
+        infrastructure.queue_build(InfrastructureType::Spaceport, 2);
+        infrastructure.queue_build(InfrastructureType::SolarPanel, 3);
+
+        let data = planet_panel_data(&world, planet_id).unwrap();
+
+        assert_eq!(data.name, "earth");
+        assert_eq!(data.system_name, "sol");
+        assert_eq!(data.moon_count, 1);
+        assert_eq!(
+            data.resources,
+            vec![(RawResource::Metals, 1.0), (RawResource::Crystals, 2.0)]
+        );
+        assert_eq!(data.energy_generation, 2.0);
+        assert_eq!(data.solar_panel_count, 2);
+        assert_eq!(
+            data.spaceport,
+            Some(Spaceport {
+                name: "earth spaceport".to_string(),
+                size: SpaceportSize::Small,
+            })
+        );
+    }
+
+    #[test]
+    fn planet_panel_prefers_left_and_flips_near_left_edge() {
+        let screen = Rect::from_min_size(Pos2::ZERO, Vec2::new(800.0, 600.0));
+
+        let left = planet_panel_placement(Pos2::new(500.0, 300.0), screen);
+        assert_eq!(left.pivot, Align2::RIGHT_CENTER);
+        assert_eq!(left.position, Pos2::new(476.0, 300.0));
+
+        let right = planet_panel_placement(Pos2::new(100.0, 20.0), screen);
+        assert_eq!(right.pivot, Align2::LEFT_CENTER);
+        assert_eq!(right.position.x, 124.0);
+        assert_eq!(right.position.y, 128.0);
     }
 }

--- a/src/world/command_processing.rs
+++ b/src/world/command_processing.rs
@@ -123,6 +123,16 @@ impl World {
                 infrastructure_type,
                 amount,
             } => {
+                if !self.can_queue_player_infrastructure(entity_id, infrastructure_type, amount) {
+                    tracing::warn!(
+                        "entity {} cannot queue {:?} x{}",
+                        self.get_entity_name(entity_id).unwrap_or_default(),
+                        infrastructure_type,
+                        amount
+                    );
+                    return;
+                }
+
                 let costs = EntityInfrastructure::get_build_costs(infrastructure_type, amount);
                 let can_afford = {
                     if let Some(cd) = self.celestial_data.get(&entity_id) {
@@ -175,7 +185,7 @@ mod tests {
     use super::*;
     use crate::command::Command;
     use crate::location::Point;
-    use crate::world::types::{CelestialBodyData, RawResource, Storable};
+    use crate::world::types::{CelestialBodyData, InfrastructureType, RawResource, Storable};
     use std::collections::HashMap;
 
     #[test]
@@ -231,5 +241,102 @@ mod tests {
         assert_eq!(stocks[&Storable::Raw(RawResource::Crystals)], 0.0);
         assert_eq!(world.celestial_data[&shipyard_id].credits, 0.0);
         assert_eq!(world.ships.len(), 1);
+    }
+
+    fn build_test_planet() -> (World, u32) {
+        let mut world = World::default();
+        let star_id = world.spawn_star("sol".to_string(), Point { x: 0, y: 0 });
+        let planet_id = world.spawn_planet("earth".to_string(), star_id, 10.0, 0.0, 0.0);
+        world.set_player_controlled(planet_id);
+        world
+            .celestial_data
+            .get_mut(&planet_id)
+            .unwrap()
+            .stocks
+            .insert(Storable::Raw(RawResource::Metals), 1_000.0);
+        (world, planet_id)
+    }
+
+    #[test]
+    fn hidden_ground_infrastructure_build_is_rejected_without_charging() {
+        let (mut world, planet_id) = build_test_planet();
+
+        world.add_command(Command::Build {
+            entity_id: planet_id,
+            infrastructure_type: InfrastructureType::Mine,
+            amount: 1,
+        });
+        world.process_commands();
+
+        assert_eq!(
+            world.celestial_data[&planet_id].stocks[&Storable::Raw(RawResource::Metals)],
+            1_000.0
+        );
+        assert!(world.infrastructure[&planet_id].build_queue.is_empty());
+    }
+
+    #[test]
+    fn fourth_spaceport_unit_is_rejected_without_charging() {
+        let (mut world, planet_id) = build_test_planet();
+        let infrastructure = world.infrastructure.get_mut(&planet_id).unwrap();
+        infrastructure
+            .infra
+            .insert(InfrastructureType::Spaceport, 2);
+        infrastructure.queue_build(InfrastructureType::Spaceport, 1);
+
+        world.add_command(Command::Build {
+            entity_id: planet_id,
+            infrastructure_type: InfrastructureType::Spaceport,
+            amount: 1,
+        });
+        world.process_commands();
+
+        assert_eq!(
+            world.celestial_data[&planet_id].stocks[&Storable::Raw(RawResource::Metals)],
+            1_000.0
+        );
+        assert_eq!(
+            world.infrastructure[&planet_id].get_queued_count(InfrastructureType::Spaceport),
+            1
+        );
+    }
+
+    #[test]
+    fn accepted_spaceport_build_charges_queues_and_updates_size_after_completion() {
+        let (mut world, planet_id) = build_test_planet();
+        world
+            .infrastructure
+            .get_mut(&planet_id)
+            .unwrap()
+            .infra
+            .insert(InfrastructureType::ConstructionFactory, 1);
+
+        world.add_command(Command::Build {
+            entity_id: planet_id,
+            infrastructure_type: InfrastructureType::Spaceport,
+            amount: 2,
+        });
+        world.process_commands();
+
+        assert_eq!(
+            world.celestial_data[&planet_id].stocks[&Storable::Raw(RawResource::Metals)],
+            800.0
+        );
+        assert_eq!(
+            world.infrastructure[&planet_id].get_queued_count(InfrastructureType::Spaceport),
+            2
+        );
+        assert!(world.spaceport_for_planet(planet_id).is_none());
+
+        world
+            .infrastructure
+            .get_mut(&planet_id)
+            .unwrap()
+            .process_construction(2.0);
+
+        assert_eq!(
+            world.spaceport_for_planet(planet_id).unwrap().size,
+            crate::world::types::SpaceportSize::Medium
+        );
     }
 }

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -11,7 +11,9 @@ use std::collections::VecDeque;
 use crate::ships::ShipType;
 use crate::world::components::{Cargo, CivilianShipAI, MiningRoute};
 use crate::world::types::{
-    BodyProfile, CelestialBodyData, Color, EntityType, MOON_COLORS, PLANET_COLORS, STAR_COLORS,
+    BodyProfile, CelestialBodyData, Color, EntityType, InfrastructureType, Spaceport,
+    SpaceportSize, MAX_SPACEPORT_UNITS, MOON_COLORS, PLANET_COLORS,
+    PLAYER_BUILDABLE_INFRASTRUCTURE, STAR_COLORS,
 };
 
 mod civ_economy;
@@ -256,7 +258,7 @@ impl World {
         }
     }
 
-    fn find_star_for_entity(&self, entity_id: EntityId) -> Option<EntityId> {
+    pub fn find_star_for_entity(&self, entity_id: EntityId) -> Option<EntityId> {
         if let Some(EntityType::Star) = self.get_entity_type(entity_id) {
             return Some(entity_id);
         }
@@ -281,6 +283,72 @@ impl World {
             }
         }
         None
+    }
+
+    /// counts moons directly orbiting a planet.
+    pub fn direct_moon_count(&self, planet_id: EntityId) -> usize {
+        if self.get_entity_type(planet_id) != Some(EntityType::Planet) {
+            return 0;
+        }
+
+        self.iter_orbitals()
+            .filter(|(entity, info)| {
+                info.anchor == planet_id && self.get_entity_type(*entity) == Some(EntityType::Moon)
+            })
+            .count()
+    }
+
+    /// returns the completed spaceport represented by a planet's infrastructure units.
+    pub fn spaceport_for_planet(&self, planet_id: EntityId) -> Option<Spaceport> {
+        if self.get_entity_type(planet_id) != Some(EntityType::Planet) {
+            return None;
+        }
+        let units = self
+            .infrastructure
+            .get(&planet_id)?
+            .get_count(InfrastructureType::Spaceport);
+        let size = SpaceportSize::from_completed_units(units)?;
+        let planet_name = self.get_entity_name(planet_id)?;
+        Some(Spaceport {
+            name: format!("{planet_name} spaceport"),
+            size,
+        })
+    }
+
+    /// current abstract energy generation from completed orbital solar panels.
+    pub fn energy_generation_for_body(&self, entity_id: EntityId) -> f32 {
+        self.infrastructure
+            .get(&entity_id)
+            .map(|infrastructure| infrastructure.get_count(InfrastructureType::SolarPanel) as f32)
+            .unwrap_or(0.0)
+    }
+
+    /// remaining spaceport units after completed and queued construction.
+    pub fn remaining_spaceport_units(&self, planet_id: EntityId) -> u32 {
+        let Some(infrastructure) = self.infrastructure.get(&planet_id) else {
+            return 0;
+        };
+        let allocated = infrastructure
+            .get_count(InfrastructureType::Spaceport)
+            .saturating_add(infrastructure.get_queued_count(InfrastructureType::Spaceport));
+        MAX_SPACEPORT_UNITS.saturating_sub(allocated)
+    }
+
+    /// whether a player build command is eligible before checking its resource cost.
+    pub fn can_queue_player_infrastructure(
+        &self,
+        planet_id: EntityId,
+        infrastructure: InfrastructureType,
+        amount: u32,
+    ) -> bool {
+        amount > 0
+            && self.is_player_controlled(planet_id)
+            && self.get_entity_type(planet_id) == Some(EntityType::Planet)
+            && self.celestial_data.contains_key(&planet_id)
+            && self.infrastructure.contains_key(&planet_id)
+            && PLAYER_BUILDABLE_INFRASTRUCTURE.contains(&infrastructure)
+            && (infrastructure != InfrastructureType::Spaceport
+                || amount <= self.remaining_spaceport_units(planet_id))
     }
 
     pub fn iter_orbitals(&self) -> impl Iterator<Item = (EntityId, OrbitalInfo)> + '_ {
@@ -545,6 +613,56 @@ mod tests {
                 second_planet
             ]
         );
+    }
+
+    #[test]
+    fn planet_queries_resolve_system_moons_spaceport_and_energy() {
+        let mut world = World::default();
+        let star_id = world.spawn_star("sol".to_string(), Point { x: 0, y: 0 });
+        let planet_id = world.spawn_planet("earth".to_string(), star_id, 10.0, 0.0, 1.0);
+        world.spawn_moon("moon".to_string(), planet_id, 2.0, 0.0, 1.0);
+        world.spawn_moon("luna-2".to_string(), planet_id, 3.0, 0.0, 1.0);
+        let infrastructure = world.infrastructure.get_mut(&planet_id).unwrap();
+        infrastructure
+            .infra
+            .insert(InfrastructureType::Spaceport, 2);
+        infrastructure
+            .infra
+            .insert(InfrastructureType::SolarPanel, 4);
+        infrastructure.queue_build(InfrastructureType::Spaceport, 1);
+        infrastructure.queue_build(InfrastructureType::SolarPanel, 3);
+
+        assert_eq!(world.find_star_for_entity(planet_id), Some(star_id));
+        assert_eq!(world.direct_moon_count(planet_id), 2);
+        assert_eq!(
+            world.spaceport_for_planet(planet_id),
+            Some(Spaceport {
+                name: "earth spaceport".to_string(),
+                size: SpaceportSize::Medium,
+            })
+        );
+        assert_eq!(world.energy_generation_for_body(planet_id), 4.0);
+        assert_eq!(world.remaining_spaceport_units(planet_id), 0);
+    }
+
+    #[test]
+    fn spaceport_size_maps_completed_units_and_labels() {
+        assert_eq!(SpaceportSize::from_completed_units(0), None);
+        assert_eq!(
+            SpaceportSize::from_completed_units(1),
+            Some(SpaceportSize::Small)
+        );
+        assert_eq!(
+            SpaceportSize::from_completed_units(2),
+            Some(SpaceportSize::Medium)
+        );
+        assert_eq!(
+            SpaceportSize::from_completed_units(3),
+            Some(SpaceportSize::Large)
+        );
+        assert_eq!(SpaceportSize::Small.label(), "small");
+        assert_eq!(SpaceportSize::Medium.label(), "medium");
+        assert_eq!(SpaceportSize::Large.label(), "large");
     }
 
     /// full-sim reproducibility: with the world-owned rng seeded, generation

--- a/src/world/types.rs
+++ b/src/world/types.rs
@@ -246,5 +246,63 @@ pub enum InfrastructureType {
     Shipyard,
     ConstructionFactory,
     // orbital
+    Spaceport,
     SolarPanel,
+}
+
+/// infrastructure types currently available through the player build flow.
+pub const PLAYER_BUILDABLE_INFRASTRUCTURE: &[InfrastructureType] = &[
+    InfrastructureType::Spaceport,
+    InfrastructureType::SolarPanel,
+];
+
+pub const MAX_SPACEPORT_UNITS: u32 = 3;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SpaceportSize {
+    Small,
+    Medium,
+    Large,
+}
+
+impl SpaceportSize {
+    pub fn from_completed_units(units: u32) -> Option<Self> {
+        match units {
+            0 => None,
+            1 => Some(Self::Small),
+            2 => Some(Self::Medium),
+            _ => Some(Self::Large),
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Small => "small",
+            Self::Medium => "medium",
+            Self::Large => "large",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Spaceport {
+    pub name: String,
+    pub size: SpaceportSize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn player_buildable_infrastructure_is_limited_and_ordered() {
+        assert_eq!(
+            PLAYER_BUILDABLE_INFRASTRUCTURE,
+            &[
+                InfrastructureType::Spaceport,
+                InfrastructureType::SolarPanel
+            ]
+        );
+        assert!(!PLAYER_BUILDABLE_INFRASTRUCTURE.contains(&InfrastructureType::Mine));
+    }
 }


### PR DESCRIPTION
## summary

- add a floating planet information panel positioned beside the selected planet
- add simple planet-owned spaceports and orbital solar panels
- limit player construction to the initial orbital infrastructure catalog
- document the provisional orbital and future energy models

## behavior

- spaceport size progresses from small to medium to large across three completed units
- completed orbital solar panels each add one informational energy-generation unit
- ground infrastructure remains functional but is no longer player-buildable
- earth starts with a small named spaceport

## validation

- cargo fmt --all
- cargo clippy
- cargo test (62 passed)